### PR TITLE
Remove unnecessary parenthesis

### DIFF
--- a/A348301.py
+++ b/A348301.py
@@ -3,7 +3,7 @@ from sympy import primorial, sieve
 
 
 def numerator(n):
-    return sum((primorial(n) // p for p in islice(sieve, n)))
+    return sum(primorial(n) // p for p in islice(sieve, n))
 
 
 def sequence(n):


### PR DESCRIPTION
Apparently they are not needed and this ends up using a generator expression https://www.python.org/dev/peps/pep-0289/.